### PR TITLE
fix: Remove calling tree command

### DIFF
--- a/git-download/src/lib.rs
+++ b/git-download/src/lib.rs
@@ -73,7 +73,6 @@ impl Downloader {
         let branch_name = &self.branch_name;
         run_cmd! {
             git pull origin $branch_name;
-            tree;
         }?;
 
         for req in &self.copy_requests {


### PR DESCRIPTION
This is only for debugging. We don't need this anymore.